### PR TITLE
Expand metainfo

### DIFF
--- a/data/dev.qwery.AddWater.metainfo.xml.in
+++ b/data/dev.qwery.AddWater.metainfo.xml.in
@@ -73,8 +73,16 @@
 	<url type="bugtracker">https://github.com/largestgithubuseronearth/addwater/issues</url>
 	<url type="vcs-browser">https://github.com/largestgithubuseronearth/addwater</url>
 	<url type="donation">https://paypal.me/RafaelMardojaiCM</url>
+  <url type="help">https://github.com/largestgithubuseronearth/addwater/blob/main/docs/troubleshooting.md</url>
+  <url type="contribute">https://github.com/largestgithubuseronearth/addwater</url>
+  <url type="translate">https://github.com/largestgithubuseronearth/addwater/tree/main/po</url>
+  <url type="contact">https://qwery.dev</url>
 
 	<!-- Technical Details -->
+  <requires>
+    <display_length compare="ge">375</display_length>
+  </requires>
+
 	<recommends>
 		<internet>always</internet>
 	</recommends>
@@ -82,7 +90,7 @@
 	<supports>
 		<control>keyboard</control>
 		<control>pointing</control>
-		<!-- i can't test touch support -->
+		<control>touch</control>
 	</supports>
 
 


### PR DESCRIPTION
- Adds various URLs
- Adds information about screen size requirements
- Adds touch support since the app uses regular GTK widgets and doesn't have any unreasonably small touch targets (meaning that it basically does support touch fully OOTB)