### PR TITLE
fix: package switcher overwritten at launch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 ## Front-facing improvements:
 
 * Dialog prompt for user to select which package to install to when multiple package formats are detected simultaneously
+* When user changes Package in prefs, refresh the interface automatically to apply to the new paths.
 * Add a function to easily get the log files for GitHub issues.
 * Add a "Restart Firefox" button to install and uninstall toasts
 * Get Flathub verification

--- a/data/gtk/preferences.ui
+++ b/data/gtk/preferences.ui
@@ -22,7 +22,7 @@
 						<child>
 							<object class="AdwComboRow" id="firefox_package_combobox">
 								<property name="title" translatable="yes">Package Format</property>
-								<property name="subtitle">Restart Add Water for this to take effect</property>
+								<property name="subtitle">Restart Add Water to Apply</property>
 								<property name="tooltip-text">Profile data not found at selected location</property>
 								<property name="has-tooltip">false</property>
 								<property name="model">

--- a/data/gtk/preferences.ui
+++ b/data/gtk/preferences.ui
@@ -22,6 +22,7 @@
 						<child>
 							<object class="AdwComboRow" id="firefox_package_combobox">
 								<property name="title" translatable="yes">Package Format</property>
+								<property name="subtitle">Restart Add Water for this to take effect</property>
 								<property name="tooltip-text">Profile data not found at selected location</property>
 								<property name="has-tooltip">false</property>
 								<property name="model">

--- a/src/apps/firefox/firefox_details.py
+++ b/src/apps/firefox/firefox_details.py
@@ -72,7 +72,6 @@ class FirefoxAppDetails:
     installer: Callable = install_for_firefox
     options: list[dict[Any, Any]] = FIREFOX_OPTIONS
     color_palettes: list = FIREFOX_COLORS
-    autofind_data_path: bool
     data_path: str
     profiles_list: list[dict[str, str]]
 
@@ -92,14 +91,14 @@ class FirefoxAppDetails:
         version = self.settings.get_int("installed-version")
         self.set_installed_version(version)
 
-        self.autofind_data_path = self.settings.get_boolean("autofind-paths")
-        # TODO ensure this handles autofind paths
-        try:
+        autofind = self.settings.get_boolean("autofind-paths")
+
+        if autofind:
             data_paths = self._find_data_paths(self.package_formats)
-        except FatalAppDetailsError as err:
-            raise FatalAppDetailsError(err)
-        # TODO make this handle having multiple available paths
-        self.set_data_path(data_paths[0]["path"])
+            self.set_data_path(data_paths[0]["path"])
+        else:
+            current_path = self.settings.get_string("data-path")
+            self.set_data_path(current_path)
 
         try:
             self.profiles_list = self._find_profiles(self.data_path)

--- a/src/apps/firefox/firefox_details.py
+++ b/src/apps/firefox/firefox_details.py
@@ -91,22 +91,18 @@ class FirefoxAppDetails:
         version = self.settings.get_int("installed-version")
         self.set_installed_version(version)
 
-        autofind = self.settings.get_boolean("autofind-paths")
-
-        if autofind:
-            data_paths = self._find_data_paths(self.package_formats)
-            self.set_data_path(data_paths[0]["path"])
-        else:
-            current_path = self.settings.get_string("data-path")
+        current_path = self.settings.get_string("data-path")
+        try:
             self.set_data_path(current_path)
+        except FileNotFoundError as err:
+            available_paths = self._find_data_paths(self.package_formats)
+            self.set_data_path(available_paths[0]["path"])
+
 
         try:
             self.profiles_list = self._find_profiles(self.data_path)
         except FileNotFoundError as err:
             log.critical(err)
-            raise FatalAppDetailsError(
-                f"App cannot continue without profile data: {err}"
-            )
 
     """PUBLIC METHODS"""
 
@@ -183,7 +179,7 @@ class FirefoxAppDetails:
             return
 
         log.error(f"Tried to set app_path to non-existant path. Path given: {new_path}")
-        raise AppDetailsException("Data path given does not exist")
+        raise FileNotFoundError("Invalid data path")
 
     def set_installed_version(self, new_version: int) -> None:
         log.debug(f"Set installed version number to {new_version}")
@@ -250,9 +246,10 @@ class FirefoxAppDetails:
         profiles.sort(reverse=True, key=_sort_profile_by_preferred)
 
         if profiles is None:
-            raise FatalAppDetailsError(
+            log.critical(
                 "installs.ini and profiles.ini exist but do not have any profiles available."
             )
+
         return profiles
 
     @staticmethod
@@ -270,19 +267,10 @@ class FirefoxAppDetails:
                 log.debug(f"Found Firefox path: {name} — {path}")
                 found.append(each)
         if not found:
-            log.error("Could not find any valid data paths. App cannot function.")
-            raise FatalAppDetailsError("Could not find any valid data paths")
+            log.critical("Could not find any valid data paths. App cannot function.")
 
         return found
 
 
 def _sort_profile_by_preferred(item: str) -> bool:
     return item["name"].endswith(" (Preferred)")
-
-
-class AppDetailsException(Exception):
-    pass
-
-
-class FatalAppDetailsError(Exception):
-    pass

--- a/src/backend.py
+++ b/src/backend.py
@@ -27,8 +27,6 @@ from addwater.components.online import OnlineManager
 from addwater.utils.mocks import mock_online
 from addwater.utils.paths import DOWNLOAD_DIR
 
-from addwater.apps.firefox.firefox_details import AppDetailsException
-
 from addwater import info
 
 log = logging.getLogger(__name__)
@@ -164,8 +162,7 @@ class AddWaterBackend:
     def set_data_path(self, new_path: str) -> None:
         try:
             self.app_details.set_data_path(new_path)
-        except AppDetailsException as err:
-            log.error(err)
+        except FileNotFoundError as err:
             raise InterfaceMisuseError(err)
 
     def set_installed_version(self, new_version: int) -> None:
@@ -223,3 +220,4 @@ class BackendFactory:
             online_manager=online_manager,
         )
         return firefox_backend
+

--- a/src/main.py
+++ b/src/main.py
@@ -101,9 +101,6 @@ class AddWaterApplication(Adw.Application):
         if not win:
             win = AddWaterWindow(application=self, backends=self.backends)
 
-        # TODO make this error handling better and more explicit
-        if not self.backends:
-            win.error_page()
         win.present()
 
     def handle_background_update(self, options):

--- a/src/main.py
+++ b/src/main.py
@@ -26,10 +26,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from addwater.apps.firefox.firefox_details import (
-    FatalAppDetailsError,
-    FirefoxAppDetails,
-)
+from addwater.apps.firefox.firefox_details import FirefoxAppDetails
 from addwater.backend import BackendFactory
 from gi.repository import Adw, Gio, GLib, Gtk
 
@@ -129,11 +126,7 @@ class AddWaterApplication(Adw.Application):
     def construct_backends(self):
         # TODO make this dynamic to find all available app details
         backends = []
-        try:
-            app_detail = FirefoxAppDetails()
-        except FatalAppDetailsError:
-            return None
-
+        app_detail = FirefoxAppDetails()
         backends.append(BackendFactory.new_from_appdetails(app_detail))
 
         return backends

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -23,7 +23,7 @@ import gi
 
 gi.require_version("Xdp", "1.0")
 
-from gi.repository import Adw, Gio, Gtk, Xdp
+from gi.repository import Adw, Gio, Gtk, Xdp, GObject
 
 from addwater import info
 from addwater.backend import InterfaceMisuseError

--- a/src/window.py
+++ b/src/window.py
@@ -57,6 +57,7 @@ class AddWaterWindow(Adw.ApplicationWindow):
             )
         if not backends:
             self.error_page()
+            return
 
         for each in backends:
             self.create_firefox_page(each)
@@ -80,7 +81,6 @@ class AddWaterWindow(Adw.ApplicationWindow):
         self.set_size_request(375, 425)  # Minimum size of window Width x Height
 
         page = self.create_error_page()
-        self.main_menu.set_sensitive(False)
         self.main_toolbar_view.set_content(page)
 
     def create_error_page(self):

--- a/src/window.py
+++ b/src/window.py
@@ -20,6 +20,8 @@
 
 import logging
 
+from os.path import exists
+
 from addwater.page import AddWaterPage
 from gi.repository import Adw, Gio, Gtk
 
@@ -55,12 +57,14 @@ class AddWaterWindow(Adw.ApplicationWindow):
             self.settings.bind(
                 "window-maximized", self, "maximized", Gio.SettingsBindFlags.DEFAULT
             )
-        if not backends:
-            self.error_page()
-            return
 
         for each in backends:
-            self.create_firefox_page(each)
+            data_path = each.get_data_path()
+            if exists(data_path):
+                self.create_firefox_page(each)
+            else:
+                log.critical("Data path has failed. App can't continue. Displaying error status page")
+                self.error_page()
 
     # TODO refactor to support as many pages as possible. only supports a single page rn
     def create_firefox_page(self, firefox_backend):
@@ -72,14 +76,7 @@ class AddWaterWindow(Adw.ApplicationWindow):
 
     """These are only called if no profile data is found"""
 
-    def error_page(
-        self,
-    ):
-        if info.PROFILE == "developer":
-            self.add_css_class("devel")
-
-        self.set_size_request(375, 425)  # Minimum size of window Width x Height
-
+    def error_page(self):
         page = self.create_error_page()
         self.main_toolbar_view.set_content(page)
 

--- a/src/window.py
+++ b/src/window.py
@@ -56,7 +56,7 @@ class AddWaterWindow(Adw.ApplicationWindow):
                 "window-maximized", self, "maximized", Gio.SettingsBindFlags.DEFAULT
             )
         if not backends:
-            return
+            self.error_page()
 
         for each in backends:
             self.create_firefox_page(each)


### PR DESCRIPTION
Fix the user's chosen package being overwritten when the AppDetails are constructed. Now there is no FatalAppDetailsError and Window has to verify whether AppDetails are okay or not before showing the page.

I would like to make this refresh the page automatically but that's another day.