### PR TITLE
Fix symbolic icon install directory

### DIFF
--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -10,5 +10,5 @@ install_data(
 symbolic_dir = 'hicolor' / 'symbolic' / 'apps'
 install_data(
   symbolic_dir / ('@0@-symbolic.svg').format('dev.qwery.AddWater'),
-  install_dir: get_option('datadir') / 'icons' / symbolic_dir / 'apps'
+  install_dir: get_option('datadir') / 'icons' / symbolic_dir
 )


### PR DESCRIPTION
Since `scalable_dir = 'hicolor' / 'scalable' / 'apps'`, the `install_dir` ends up being

```
install_dir: get_option('datadir') / 'icons' / 'hicolor' / 'scalable' / 'apps' / 'apps'
```

The symbolic icon ends up being installed in `/usr/share/icons/hicolor/symbolic/apps/apps/`