### PR TITLE
gh(actions): Use Flathub's flatpak workflow

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,11 +5,11 @@ jobs:
   Flatpak-Builder-Action:
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
       - uses: actions/checkout@v4
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
+      - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
         with:
           bundle: dev.qwery.AddWater.Devel.flatpak
           manifest-path: build-aux/dev.qwery.AddWater.Devel.json

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,7 +5,7 @@ jobs:
   Flatpak-Builder-Action:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-46
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/user_flatpak.yml
+++ b/.github/workflows/user_flatpak.yml
@@ -9,7 +9,7 @@ jobs:
   Flatpak-Builder-Action:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-46
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/user_flatpak.yml
+++ b/.github/workflows/user_flatpak.yml
@@ -9,11 +9,11 @@ jobs:
   Flatpak-Builder-Action:
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
       - uses: actions/checkout@v4
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
+      - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
         with:
           bundle: dev.qwery.AddWater.flatpak
           manifest-path: build-aux/dev.qwery.AddWater.json


### PR DESCRIPTION
The official flatpak-github-actions workflow is still broken due to a deprecated dependency and there's no sign of when it will be fixed.