### PR TITLE
Update POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,7 @@ data/dev.qwery.AddWater.gschema.xml.in
 data/gtk/addwater-page.ui
 data/gtk/help-overlay.ui
 data/gtk/preferences.ui
+data/gtk/profile-selector.ui
 data/gtk/window.ui
 
 src/main.py
@@ -12,5 +13,6 @@ src/window.py
 src/preferences.py
 src/page.py
 src/apps/firefox/firefox_options.py
+src/gui/option_factory.py
 
 src/utils/background.py


### PR DESCRIPTION
Add missing source files to POTFILES.in as reported in [addwater module page](https://l10n.gnome.org/module/addwater/) at Damned Lies:

> There are some missing files from POTFILES.in:
>
>  -  data/gtk/profile-selector.ui
>  -  src/gui/option_factory.py

This adds 3 strings to the POT file:

```diff
@@ -295,6 +295,15 @@ msgstr ""
 msgid "Reset and Close App"
 msgstr ""
 
+#. Translators: Profile as in Firefox profile/account
+#: data/gtk/profile-selector.ui:5
+msgid "Profile"
+msgstr ""
+
+#: data/gtk/profile-selector.ui:6
+msgid "Select profile to apply changes toward"
+msgstr ""
+
 #: data/gtk/window.ui:19
 msgid "Main Menu"
 msgstr ""
@@ -527,6 +536,10 @@ msgstr ""
 msgid "Show Bookmarks bar while in fullscreen"
 msgstr ""
 
+#: src/gui/option_factory.py:93
+msgid "More Information"
+msgstr ""
+
 #: src/utils/background.py:86
 msgid "Theme updated"
 msgstr ""
```