### PR TITLE
Add XDG directory support for Firefox installations

### DIFF
--- a/src/apps/firefox/firefox_paths.py
+++ b/src/apps/firefox/firefox_paths.py
@@ -1,12 +1,12 @@
 from os.path import expanduser
 
 # FIREFOX PATHS
-BASE = expanduser("~/.mozilla/firefox/")
-BASE_XDG = expanduser("~/.config/mozilla/firefox/")
-FLATPAK = expanduser("~/.var/app/org.mozilla.firefox/.mozilla/firefox/")
-FLATPAK_XDG = expanduser("~/.var/app/org.mozilla.firefox/.config/mozilla/firefox/")
-SNAP = expanduser("~/snap/firefox/common/.mozilla/firefox/")
-SNAP_XDG = expanduser("~/snap/firefox/common/.config/mozilla/firefox/")
+BASE_LEGACY = expanduser("~/.mozilla/firefox/")
+BASE = expanduser("~/.config/mozilla/firefox/")
+FLATPAK_LEGACY = expanduser("~/.var/app/org.mozilla.firefox/.mozilla/firefox/")
+FLATPAK = expanduser("~/.var/app/org.mozilla.firefox/.config/mozilla/firefox/")
+SNAP_LEGACY = expanduser("~/snap/firefox/common/.mozilla/firefox/")
+SNAP = expanduser("~/snap/firefox/common/.config/mozilla/firefox/")
 
 LIBREWOLF_BASE = expanduser("~/.librewolf/")
 LIBREWOLF_FLATPAK = expanduser("~/.var/app/io.gitlab.librewolf-community/.librewolf/")
@@ -20,12 +20,12 @@ WATERFOX_FLATPAK = expanduser("~/.var/app/net.waterfox.waterfox/.waterfox")
 CACHY_BASE = expanduser("~/.cachy")
 
 FIREFOX_PATHS = [
+    {"name": "Base (Alt)", "path": BASE_LEGACY},
     {"name": "Base", "path": BASE},
-    {"name": "Base (XDG)", "path": BASE_XDG},
+    {"name": "Flatpak (Alt)", "path": FLATPAK_LEGACY},
     {"name": "Flatpak", "path": FLATPAK},
-    {"name": "Flatpak (XDG)", "path": FLATPAK_XDG},
+    {"name": "Snap (Alt)", "path": SNAP_LEGACY},
     {"name": "Snap", "path": SNAP},
-    {"name": "Snap (XDG)", "path": SNAP_XDG},
     {"name": "Librewolf Base", "path": LIBREWOLF_BASE},
     {"name": "Librewolf Flatpak", "path": LIBREWOLF_FLATPAK},
     {"name": "Floorp Base", "path": FLOORP_BASE},


### PR DESCRIPTION
- Add support for ~/.config/mozilla/firefox/ (native Firefox XDG)
- Add support for Flatpak XDG path
- Add support for Snap XDG path

Firefox now uses XDG directories for new installations, so Add Water
needs to check both the legacy ~/.mozilla/firefox/ and the new
~/.config/mozilla/firefox/ locations.