### PR TITLE
use xdg_config_home if set for firefox paths

### DIFF
--- a/build-aux/dev.qwery.AddWater.Devel.json
+++ b/build-aux/dev.qwery.AddWater.Devel.json
@@ -11,7 +11,7 @@
         "--device=dri",
         "--socket=wayland",
         "--filesystem=~/.mozilla/firefox/:rw",
-        "--filesystem=~/.config/mozilla/firefox/:rw",
+        "--firesystem=xdg-config/mozilla/firefox/:rw",
         "--filesystem=~/.var/app/org.mozilla.firefox/.mozilla/firefox/:rw",
         "--filesystem=~/.var/app/org.mozilla.firefox/config/mozilla/firefox/:rw",
         "--filesystem=~/snap/firefox/common/.mozilla/firefox/:rw",

--- a/src/apps/firefox/firefox_paths.py
+++ b/src/apps/firefox/firefox_paths.py
@@ -12,7 +12,7 @@ SNAP_LEGACY = expanduser("~/snap/firefox/common/.mozilla/firefox/")
 SNAP = expanduser("~/snap/firefox/common/.config/mozilla/firefox/")
 
 LIBREWOLF_BASE_LEGACY = expanduser("~/.librewolf/")
-LIBREWOLF_BASE = expanduser("~/.config/librewolf/librewolf")
+LIBREWOLF_BASE = expanduser("f"{config_dir}/librewolf/librewolf")
 LIBREWOLF_FLATPAK_LEGACY = expanduser("~/.var/app/io.gitlab.librewolf-community/.librewolf/")
 LIBREWOLF_FLATPAK = expanduser("~/.var/app/io.gitlab.librewolf-community/config/librewolf/librewolf/")
 

--- a/src/apps/firefox/firefox_paths.py
+++ b/src/apps/firefox/firefox_paths.py
@@ -1,7 +1,7 @@
 from os.path import expanduser
 from os import environ
 
-config_dir = environ.get("XDG_CONFIG_HOME", expanduser("~/.config"))
+config_dir = environ.get("HOST_XDG_CONFIG_HOME", expanduser("~/.config"))
 
 # FIREFOX PATHS
 BASE_LEGACY = expanduser("~/.mozilla/firefox/")

--- a/src/apps/firefox/firefox_paths.py
+++ b/src/apps/firefox/firefox_paths.py
@@ -1,8 +1,11 @@
 from os.path import expanduser
+from os import environ
+
+config_dir = environ.get("XDG_CONFIG_HOME", expanduser("~/.config"))
 
 # FIREFOX PATHS
 BASE_LEGACY = expanduser("~/.mozilla/firefox/")
-BASE = expanduser("~/.config/mozilla/firefox/")
+BASE = expanduser(f"{config_dir}/mozilla/firefox/")
 FLATPAK_LEGACY = expanduser("~/.var/app/org.mozilla.firefox/.mozilla/firefox/")
 FLATPAK = expanduser("~/.var/app/org.mozilla.firefox/config/mozilla/firefox/")
 SNAP_LEGACY = expanduser("~/snap/firefox/common/.mozilla/firefox/")


### PR DESCRIPTION
Read `XDG_CONFIG_HOME` for firefox paths.

I'm not sure how librewolf handles setting its config path (i.e. hard coded to use `~/.config` or use `XDG_CONFIG_HOME` with a fallback) so I left that out, but I can update this PR if it's the latter.

I wasn't able to test the flatpak changes but `xdg-config` should be a valid portal https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access